### PR TITLE
[fix][broker]Make LedgerOffloaderFactory compatible with old version.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderFactory.java
@@ -42,11 +42,29 @@ public interface LedgerOffloaderFactory<T extends LedgerOffloader> {
     boolean isDriverSupported(String driverName);
 
     /**
-     * Create a ledger offloader with the provided configuration, user-metadata and scheduler.
+     * Create a ledger offloader with the provided configuration, user-metadata, scheduler and offloaderStats.
      *
      * @param offloadPolicies offload policies
      * @param userMetadata user metadata
      * @param scheduler scheduler
+     * @return the offloader instance
+     * @throws IOException when fail to create an offloader
+     */
+    default T create(OffloadPoliciesImpl offloadPolicies,
+             Map<String, String> userMetadata,
+             OrderedScheduler scheduler)
+            throws IOException {
+        return create(offloadPolicies, userMetadata, scheduler, null);
+    }
+
+
+    /**
+     * Create a ledger offloader with the provided configuration, user-metadata, scheduler and offloaderStats.
+     *
+     * @param offloadPolicies offload policies
+     * @param userMetadata user metadata
+     * @param scheduler scheduler
+     * @param offloaderStats offloaderStats
      * @return the offloader instance
      * @throws IOException when fail to create an offloader
      */
@@ -56,6 +74,7 @@ public interface LedgerOffloaderFactory<T extends LedgerOffloader> {
              LedgerOffloaderStats offloaderStats)
         throws IOException;
 
+
     /**
      * Create a ledger offloader with the provided configuration, user-metadata, schema storage and scheduler.
      *
@@ -63,6 +82,26 @@ public interface LedgerOffloaderFactory<T extends LedgerOffloader> {
      * @param userMetadata user metadata
      * @param schemaStorage used for schema lookup in offloader
      * @param scheduler scheduler
+     * @return the offloader instance
+     * @throws IOException when fail to create an offloader
+     */
+    default T create(OffloadPoliciesImpl offloadPolicies,
+                     Map<String, String> userMetadata,
+                     SchemaStorage schemaStorage,
+                     OrderedScheduler scheduler)
+            throws IOException {
+        return create(offloadPolicies, userMetadata, schemaStorage, scheduler, null);
+    }
+
+    /**
+     * Create a ledger offloader with the provided configuration, user-metadata, schema storage,
+     * scheduler and offloaderStats.
+     *
+     * @param offloadPolicies offload policies
+     * @param userMetadata user metadata
+     * @param schemaStorage used for schema lookup in offloader
+     * @param scheduler scheduler
+     * @param offloaderStats offloaderStats
      * @return the offloader instance
      * @throws IOException when fail to create an offloader
      */

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderFactory.java
@@ -50,12 +50,10 @@ public interface LedgerOffloaderFactory<T extends LedgerOffloader> {
      * @return the offloader instance
      * @throws IOException when fail to create an offloader
      */
-    default T create(OffloadPoliciesImpl offloadPolicies,
+    T create(OffloadPoliciesImpl offloadPolicies,
              Map<String, String> userMetadata,
              OrderedScheduler scheduler)
-            throws IOException {
-        return create(offloadPolicies, userMetadata, scheduler, null);
-    }
+            throws IOException;
 
 
     /**
@@ -90,7 +88,7 @@ public interface LedgerOffloaderFactory<T extends LedgerOffloader> {
                      SchemaStorage schemaStorage,
                      OrderedScheduler scheduler)
             throws IOException {
-        return create(offloadPolicies, userMetadata, schemaStorage, scheduler, null);
+        return create(offloadPolicies, userMetadata, scheduler);
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStatsDisable.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStatsDisable.java
@@ -20,9 +20,9 @@ package org.apache.bookkeeper.mledger;
 
 import java.util.concurrent.TimeUnit;
 
-class LedgerOffloaderStatsDisable implements LedgerOffloaderStats {
+public class LedgerOffloaderStatsDisable implements LedgerOffloaderStats {
 
-    static final LedgerOffloaderStats INSTANCE = new LedgerOffloaderStatsDisable();
+    public static final LedgerOffloaderStats INSTANCE = new LedgerOffloaderStatsDisable();
 
     private LedgerOffloaderStatsDisable() {
 

--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/FileSystemLedgerOffloaderFactory.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/FileSystemLedgerOffloaderFactory.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.LedgerOffloaderFactory;
 import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStatsDisable;
 import org.apache.bookkeeper.mledger.offload.filesystem.impl.FileSystemManagedLedgerOffloader;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 
@@ -30,6 +31,13 @@ public class FileSystemLedgerOffloaderFactory implements LedgerOffloaderFactory<
     @Override
     public boolean isDriverSupported(String driverName) {
         return FileSystemManagedLedgerOffloader.driverSupported(driverName);
+    }
+
+    @Override
+    public FileSystemManagedLedgerOffloader create(OffloadPoliciesImpl offloadPolicies,
+                                                   Map<String, String> userMetadata, OrderedScheduler scheduler)
+            throws IOException {
+        return create(offloadPolicies, userMetadata, scheduler, LedgerOffloaderStatsDisable.INSTANCE);
     }
 
     @Override

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/JCloudLedgerOffloaderFactory.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/JCloudLedgerOffloaderFactory.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.LedgerOffloaderFactory;
 import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
+import org.apache.bookkeeper.mledger.LedgerOffloaderStatsDisable;
 import org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreManagedLedgerOffloader;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.JCloudBlobStoreProvider;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.TieredStorageConfiguration;
@@ -42,6 +43,12 @@ public class JCloudLedgerOffloaderFactory implements LedgerOffloaderFactory<Blob
     @Override
     public boolean isDriverSupported(String driverName) {
         return JCloudBlobStoreProvider.driverSupported(driverName);
+    }
+
+    @Override
+    public BlobStoreManagedLedgerOffloader create(OffloadPoliciesImpl offloadPolicies, Map<String, String> userMetadata,
+                                                  OrderedScheduler scheduler) throws IOException {
+        return create(offloadPolicies, userMetadata, scheduler, LedgerOffloaderStatsDisable.INSTANCE);
     }
 
     @Override


### PR DESCRIPTION
<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->

### Motivation
After #13833, we change the signature of LedgerOffloaderFactory#create.

Before: no offloaderStats.
```
    default T create(OffloadPoliciesImpl offloadPolicies,
                     Map<String, String> userMetadata,
                     SchemaStorage schemaStorage,
                     OrderedScheduler scheduler)
            throws IOException {
        return create(offloadPolicies, userMetadata, scheduler);
    }
```
After: add offloaderStats.
```
    default T create(OffloadPoliciesImpl offloadPolicies,
                     Map<String, String> userMetadata,
                     SchemaStorage schemaStorage,
                     OrderedScheduler scheduler,
                     LedgerOffloaderStats offloaderStats)
            throws IOException {
        return create(offloadPolicies, userMetadata, scheduler, offloaderStats);
    }
```

And in PulsarService#createManagedLedgerOffloader line_1402, it changes the way to create an offloader.

Before: no offloaderStats
```
                    return offloaderFactory.create(
                        offloadPolicies,
                        ImmutableMap.of(
                            LedgerOffloader.METADATA_SOFTWARE_VERSION_KEY.toLowerCase(), PulsarVersion.getVersion(),
                            LedgerOffloader.METADATA_SOFTWARE_GITSHA_KEY.toLowerCase(), PulsarVersion.getGitSha(),
                            LedgerOffloader.METADATA_PULSAR_CLUSTER_NAME.toLowerCase(), config.getClusterName()
                        ),
                        schemaStorage,
                        getOffloaderScheduler(offloadPolicies));
```

After: add offloaderStats
```
return offloaderFactory.create(
                        offloadPolicies,
                        ImmutableMap.of(
                            LedgerOffloader.METADATA_SOFTWARE_VERSION_KEY.toLowerCase(), PulsarVersion.getVersion(),
                            LedgerOffloader.METADATA_SOFTWARE_GITSHA_KEY.toLowerCase(), PulsarVersion.getGitSha(),
                            LedgerOffloader.METADATA_PULSAR_CLUSTER_NAME.toLowerCase(), config.getClusterName()
                        ),
                        schemaStorage, getOffloaderScheduler(offloadPolicies), this.offloaderStats);
```


But some users may use the old version LedgerOffloaderFactory in the offloader nar, when pulsar load the offloader nar, it will use the LedgerOffloaderFactory in the offloader nar, the LedgerOffloaderFactory#create has no param `offloaderStats`. Then it will throw an exception as follows:
```
2023-03-23T23:59:42,947 - ERROR - [main:PulsarService@918] - Failed to start Pulsar service: java.lang.AbstractMethodError: Receiver class io.streamnative.tieredstorage.pulsar.PulsarOffloaderFactory does not define or inherit an implementation of the resolved method 'abstract org.apache.bookkeeper.mledger.LedgerOffloader create(org.apache.pulsar.common.policies.data.OffloadPoliciesImpl, java.util.Map, org.apache.bookkeeper.common.util.OrderedScheduler, org.apache.bookkeeper.mledger.LedgerOffloaderStats)' of interface org.apache.bookkeeper.mledger.LedgerOffloaderFactory.
org.apache.pulsar.broker.PulsarServerException: java.lang.AbstractMethodError: Receiver class io.streamnative.tieredstorage.pulsar.PulsarOffloaderFactory does not define or inherit an implementation of the resolved method 'abstract org.apache.bookkeeper.mledger.LedgerOffloader create(org.apache.pulsar.common.policies.data.OffloadPoliciesImpl, java.util.Map, org.apache.bookkeeper.common.util.OrderedScheduler, org.apache.bookkeeper.mledger.LedgerOffloaderStats)' of interface org.apache.bookkeeper.mledger.LedgerOffloaderFactory.
	at org.apache.pulsar.broker.PulsarService.createManagedLedgerOffloader(PulsarService.java:1422) ~[classes/:?]
	at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:780) ~[classes/:?]
	at org.apache.pulsar.PulsarBrokerStarter$BrokerStarter.start(PulsarBrokerStarter.java:276) ~[classes/:?]
	at org.apache.pulsar.PulsarBrokerStarter.main(PulsarBrokerStarter.java:356) ~[classes/:?]
```

So we should make LedgerOffloaderFactory#create compatible with the previous version, and revert the origin signature to LedgerOffloaderFactory for compatibility.


After this PR, the user upgrades the `managed-ledger` dependency(LedgerOffloaderFactory is defined in `managed-ledger`). So the user offloader nar LedgerOffloaderFactory has both methods. One is with offloaderStats, another one is without offloaderStats.

If the pulsar is the old version, it loads the offloader nar, and using LedgerOffloaderFactory#create without offloadStats to create offloader. It works.

If the pulsar is the new version, it loads the offloader nar, and using LedgerOffloaderFactory#create with offloadStats to create the offloader. It also works.



<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
